### PR TITLE
Hide app from dock

### DIFF
--- a/DarkModeSwitch.xcodeproj/project.pbxproj
+++ b/DarkModeSwitch.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -360,6 +361,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Summary
- Adds `INFOPLIST_KEY_LSUIElement = YES` to build settings
- Prevents the app from appearing in the dock
- Makes it a pure menu bar application

## Test plan
- [ ] Build and run the app
- [ ] Verify app does not appear in the dock
- [ ] Verify menu bar functionality still works