### PR TITLE
chore: add CI workflow for building, testing, and linting Swift project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,19 @@ jobs:
           CODE_SIGNING_ALLOWED=NO \
           test
 
+    - name: Generate Coverage Report
+      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+      run: |
+        xcrun xccov view --report --json UnitTestsResults.xcresult > coverage_report.json
+
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: ./UnitTestsResults.xcresult
+        files: coverage_report.json
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
-        flags: unittests
+        # flags: unittests
         # exclude: |
         #   **/Tests/**
         #   **/*.xctest/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Run Unit Tests
       run: |
         xcodebuild -project DarkModeSwitch.xcodeproj \
-          # -scheme Tests \
+          -scheme Tests \
           -testPlan UnitTests \
           -derivedDataPath build \
           -enableCodeCoverage YES \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Show Xcode version
       run: xcodebuild -version
     
+    - name: Install xcpretty
+      run: gem install xcpretty
+    
     - name: Build App (Debug)
       run: |
         xcodebuild -project DarkModeSwitch.xcodeproj \
@@ -33,42 +36,37 @@ jobs:
           -configuration Debug \
           -derivedDataPath build \
           CODE_SIGNING_ALLOWED=NO \
-          build
+          build \
+          | xcpretty
     
     - name: Run Unit Tests
       run: |
+        mkdir -p TestResults
         xcodebuild -project DarkModeSwitch.xcodeproj \
           -scheme Tests \
           -testPlan UnitTests \
           -derivedDataPath build \
           -enableCodeCoverage YES \
           -resultBundlePath TestResults/AppTests.xcresult \
+          CODE_SIGNING_ALLOWED=NO \
           test \
-          CODE_SIGNING_ALLOWED=NO
+          | xcpretty --report junit --output TestResults/junit.xml
 
     - name: Generate Coverage Report
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       run: |
         xcrun xccov view --report --json TestResults/AppTests.xcresult > coverage.json
+        xcrun xccov view --report TestResults/AppTests.xcresult > coverage.txt
     
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: ./coverage.json
-        flags: unittests
+        files: TestResults/junit.xml
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: Matejkob/macos-dark-mode-switch
         fail_ci_if_error: false
     
-    - name: Upload Test Results
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results-${{ matrix.os }}-xcode-${{ matrix.xcode }}
-        path: TestResults/
-        retention-days: 7
-
   # lint:
   #   name: Swift Lint
   #   runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,18 +50,15 @@ jobs:
           -resultBundlePath TestResults/AppTests.xcresult \
           CODE_SIGNING_ALLOWED=NO \
           test \
-          | xcpretty
-
-    - name: Generate Coverage Report
-      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-      run: |
-        xcrun xccov view --report --json TestResults/AppTests.xcresult > coverage.json
+          | xcpretty --report junit
     
+    - name: Test files
+      run: cat build/reports/junit.xml
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: coverage.json
+        files: build/reports/junit.xml
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,11 @@ jobs:
       run: |
         # Convert xcresult to lcov format using slather
         slather coverage \
+          -f lcov \
           --scheme Tests \
           --workspace DarkModeSwitch.xcworkspace \
-          --binary-basename DarkModeSwitch \
+          --build-directory .build/DerivedData \
           --output-directory . \
-          --lcov \
           --ignore "*Tests*" \
           --ignore "*.xctest*" \
           DarkModeSwitch.xcodeproj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
           -scheme Tests \
           -configuration Debug \
           -testPlan UnitTests \
-          # -derivedDataPath .build/DerivedData \
           -enableCodeCoverage YES \
-          # -resultBundlePath UnitTestsResults.xcresult \
           CODE_SIGNING_ALLOWED=NO \
           test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,31 +51,18 @@ jobs:
           CODE_SIGNING_ALLOWED=NO \
           test
 
-    - name: Install slather
-      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-      run: gem install slather
-    
-    - name: Convert xcresult to lcov
-      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-      run: |
-        # Convert xcresult to lcov format using slather
-        slather coverage \
-          -f lcov \
-          --scheme Tests \
-          --workspace DarkModeSwitch.xcworkspace \
-          --build-directory .build/DerivedData \
-          --output-directory . \
-          --ignore "*Tests*" \
-          --ignore "*.xctest*" \
-          DarkModeSwitch.xcodeproj
-    
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: ./coverage.lcov
+        xcode: true
+        xcode_archive_path: ./UnitTestsResults.xcresult
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+        flags: unittests
+        # exclude: |
+        #   **/Tests/**
+        #   **/*.xctest/**
     
   # lint:
   #   name: Swift Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,27 +45,24 @@ jobs:
           -scheme Tests \
           -configuration Debug \
           -testPlan UnitTests \
+          -derivedDataPath .build/DerivedData \
           -enableCodeCoverage YES \
+          -resultBundlePath UnitTestsResults.xcresult \
           CODE_SIGNING_ALLOWED=NO \
           test
 
-    # - name: Generate Coverage Report
-    #   if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-    #   run: |
-    #     xcrun xccov view --report --json UnitTestsResults.xcresult > coverage_report.json
-    #     cat coverage_report.json
+    - name: Generate Coverage Report
+      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+      run: |
+        xcrun xccov view --report --json UnitTestsResults.xcresult > coverage_report.json
+        cat coverage_report.json
 
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v4
       with:
-        # files: coverage_report.json
+        file: coverage_report.json
         token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false
-        # flags: unittests
-        # exclude: |
-        #   **/Tests/**
-        #   **/*.xctest/**
     
   # lint:
   #   name: Swift Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       run: |
         xcrun xccov view --report --json UnitTestsResults.xcresult > coverage_report.json
+        cat coverage_report.json
 
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,30 @@ jobs:
           -resultBundlePath UnitTestsResults.xcresult \
           CODE_SIGNING_ALLOWED=NO \
           test
+
+    - name: Install slather
+      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+      run: gem install slather
+    
+    - name: Convert xcresult to lcov
+      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+      run: |
+        # Convert xcresult to lcov format using slather
+        slather coverage \
+          --scheme Tests \
+          --workspace DarkModeSwitch.xcworkspace \
+          --binary-basename DarkModeSwitch \
+          --output-directory . \
+          --lcov \
+          --ignore "*Tests*" \
+          --ignore "*.xctest*" \
+          DarkModeSwitch.xcodeproj
+    
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: # TODO: Add file path
+        files: ./coverage.lcov
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
           -derivedDataPath build \
           -enableCodeCoverage YES \
           -resultBundlePath TestResults/AppTests.xcresult \
-          CODE_SIGNING_ALLOWED=NO \
-          test
+          test \
+          CODE_SIGNING_ALLOWED=NO
 
     - name: Generate Coverage Report
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
@@ -68,37 +68,37 @@ jobs:
         path: TestResults/
         retention-days: 7
 
-  lint:
-    name: Swift Lint
-    runs-on: macos-latest
+  # lint:
+  #   name: Swift Lint
+  #   runs-on: macos-latest
     
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v4
     
-    - name: Install SwiftLint
-      run: brew install swiftlint
+  #   - name: Install SwiftLint
+  #     run: brew install swiftlint
     
-    - name: Run SwiftLint
-      run: swiftlint lint --reporter github-actions-logging
+  #   - name: Run SwiftLint
+  #     run: swiftlint lint --reporter github-actions-logging
 
-  check-format:
-    name: Check Swift Format
-    runs-on: macos-latest
+  # check-format:
+  #   name: Check Swift Format
+  #   runs-on: macos-latest
     
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout code
+  #     uses: actions/checkout@v4
     
-    - name: Install swift-format
-      run: brew install swift-format
+  #   - name: Install swift-format
+  #     run: brew install swift-format
     
-    - name: Check formatting
-      run: |
-        swift-format lint --recursive \
-          --parallel \
-          --strict \
-          App/ \
-          LaunchAgent/ \
-          Tests/ \
-          Packages/
+  #   - name: Check formatting
+  #     run: |
+  #       swift-format lint --recursive \
+  #         --parallel \
+  #         --strict \
+  #         App/ \
+  #         LaunchAgent/ \
+  #         Tests/ \
+  #         Packages/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-15]
+        xcode: ['16.4']
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+    
+    - name: Show Xcode version
+      run: xcodebuild -version
+    
+    - name: Build App (Debug)
+      run: |
+        xcodebuild -project DarkModeSwitch.xcodeproj \
+          -scheme App \
+          -configuration Debug \
+          -derivedDataPath build \
+          CODE_SIGNING_ALLOWED=NO \
+          build
+    
+    - name: Run Unit Tests
+      run: |
+        xcodebuild -project DarkModeSwitch.xcodeproj \
+          # -scheme Tests \
+          -testPlan UnitTests \
+          -derivedDataPath build \
+          -enableCodeCoverage YES \
+          -resultBundlePath TestResults/AppTests.xcresult \
+          CODE_SIGNING_ALLOWED=NO \
+          test
+
+    - name: Generate Coverage Report
+      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+      run: |
+        xcrun xccov view --report --json TestResults/AppTests.xcresult > coverage.json
+    
+    - name: Upload Coverage to Codecov
+      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.json
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+    
+    - name: Upload Test Results
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-${{ matrix.os }}-xcode-${{ matrix.xcode }}
+        path: TestResults/
+        retention-days: 7
+
+  lint:
+    name: Swift Lint
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Install SwiftLint
+      run: brew install swiftlint
+    
+    - name: Run SwiftLint
+      run: swiftlint lint --reporter github-actions-logging
+
+  check-format:
+    name: Check Swift Format
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Install swift-format
+      run: brew install swift-format
+    
+    - name: Check formatting
+      run: |
+        swift-format lint --recursive \
+          --parallel \
+          --strict \
+          App/ \
+          LaunchAgent/ \
+          Tests/ \
+          Packages/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,21 +50,19 @@ jobs:
           -resultBundlePath TestResults/AppTests.xcresult \
           CODE_SIGNING_ALLOWED=NO \
           test \
-          | xcpretty --report junit --output TestResults/junit.xml
+          | xcpretty
 
     - name: Generate Coverage Report
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       run: |
         xcrun xccov view --report --json TestResults/AppTests.xcresult > coverage.json
-        xcrun xccov view --report TestResults/AppTests.xcresult > coverage.txt
     
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: TestResults/junit.xml
+        files: coverage.json
         token: ${{ secrets.CODECOV_TOKEN }}
-        slug: Matejkob/macos-dark-mode-switch
         fail_ci_if_error: false
     
   # lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,31 +34,27 @@ jobs:
         xcodebuild -project DarkModeSwitch.xcodeproj \
           -scheme App \
           -configuration Debug \
-          -derivedDataPath build \
+          -derivedDataPath .build \
           CODE_SIGNING_ALLOWED=NO \
           build \
           | xcpretty
     
     - name: Run Unit Tests
       run: |
-        mkdir -p TestResults
-        xcodebuild -project DarkModeSwitch.xcodeproj \
+        xcodebuild -workspace DarkModeSwitch.xcworkspace \
           -scheme Tests \
+          -configuration Debug \
           -testPlan UnitTests \
-          -derivedDataPath build \
+          -derivedDataPath .build/DerivedData \
           -enableCodeCoverage YES \
-          -resultBundlePath TestResults/AppTests.xcresult \
+          -resultBundlePath UnitTestsResults.xcresult \
           CODE_SIGNING_ALLOWED=NO \
-          test \
-          | xcpretty --report junit
-    
-    - name: Test files
-      run: cat build/reports/junit.xml
+          test
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: build/reports/junit.xml
+        files: # TODO: Add file path
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,23 +45,23 @@ jobs:
           -scheme Tests \
           -configuration Debug \
           -testPlan UnitTests \
-          -derivedDataPath .build/DerivedData \
+          # -derivedDataPath .build/DerivedData \
           -enableCodeCoverage YES \
-          -resultBundlePath UnitTestsResults.xcresult \
+          # -resultBundlePath UnitTestsResults.xcresult \
           CODE_SIGNING_ALLOWED=NO \
           test
 
-    - name: Generate Coverage Report
-      if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-      run: |
-        xcrun xccov view --report --json UnitTestsResults.xcresult > coverage_report.json
-        cat coverage_report.json
+    # - name: Generate Coverage Report
+    #   if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
+    #   run: |
+    #     xcrun xccov view --report --json UnitTestsResults.xcresult > coverage_report.json
+    #     cat coverage_report.json
 
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        files: coverage_report.json
+        # files: coverage_report.json
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
         # flags: unittests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,7 @@ jobs:
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
       uses: codecov/codecov-action@v5
       with:
-        xcode: true
-        xcode_archive_path: ./UnitTestsResults.xcresult
+        files: ./UnitTestsResults.xcresult
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
         flags: unittests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,12 @@ jobs:
     
     - name: Upload Coverage to Codecov
       if: matrix.os == 'macos-15' && matrix.xcode == '16.4'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.json
+        files: ./coverage.json
         flags: unittests
-        name: codecov-umbrella
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: Matejkob/macos-dark-mode-switch
         fail_ci_if_error: false
     
     - name: Upload Test Results

--- a/DarkModeSwitch.xcodeproj/project.pbxproj
+++ b/DarkModeSwitch.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		453477522E0AC32F00401C3C /* Utilities in Frameworks */ = {isa = PBXBuildFile; productRef = 453477512E0AC32F00401C3C /* Utilities */; };
-		457CD7D62E0ECF5B00FDBCA0 /* Utilities in Frameworks */ = {isa = PBXBuildFile; productRef = 45EE1B2D2E0DEF380085A617 /* Utilities */; };
+		45150B1E2E1067D400B0B977 /* Utilities in Frameworks */ = {isa = PBXBuildFile; productRef = 45150B1D2E1067D400B0B977 /* Utilities */; };
 		45EE1B372E0DF0810085A617 /* LaunchAgent in Resources */ = {isa = PBXBuildFile; fileRef = 45EE1B262E0DEF2C0085A617 /* LaunchAgent */; };
 		45F7F7A82E0E9F7E0085CCD0 /* AppearanceSwitcher in Frameworks */ = {isa = PBXBuildFile; productRef = 45F7F7A72E0E9F7E0085CCD0 /* AppearanceSwitcher */; };
 /* End PBXBuildFile section */
@@ -104,7 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				453477522E0AC32F00401C3C /* Utilities in Frameworks */,
+				45150B1E2E1067D400B0B977 /* Utilities in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,7 +118,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				457CD7D62E0ECF5B00FDBCA0 /* Utilities in Frameworks */,
 				45F7F7A82E0E9F7E0085CCD0 /* AppearanceSwitcher in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -181,7 +179,7 @@
 			);
 			name = App;
 			packageProductDependencies = (
-				453477512E0AC32F00401C3C /* Utilities */,
+				45150B1D2E1067D400B0B977 /* Utilities */,
 			);
 			productName = DarkModeSwitch;
 			productReference = 4578DE832E05783800C35580 /* App.app */;
@@ -227,7 +225,6 @@
 			);
 			name = LaunchAgent;
 			packageProductDependencies = (
-				45EE1B2D2E0DEF380085A617 /* Utilities */,
 				45F7F7A72E0E9F7E0085CCD0 /* AppearanceSwitcher */,
 			);
 			productName = LaunchAgent;
@@ -265,6 +262,9 @@
 			);
 			mainGroup = 4578DE7A2E05783800C35580;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				45150B1C2E1067D400B0B977 /* XCLocalSwiftPackageReference "Packages/Utilities" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4578DE842E05783800C35580 /* Products */;
 			projectDirPath = "";
@@ -620,12 +620,15 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCSwiftPackageProductDependency section */
-		453477512E0AC32F00401C3C /* Utilities */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Utilities;
+/* Begin XCLocalSwiftPackageReference section */
+		45150B1C2E1067D400B0B977 /* XCLocalSwiftPackageReference "Packages/Utilities" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/Utilities;
 		};
-		45EE1B2D2E0DEF380085A617 /* Utilities */ = {
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		45150B1D2E1067D400B0B977 /* Utilities */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Utilities;
 		};

--- a/DarkModeSwitch.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/DarkModeSwitch.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1640"
-   version = "2.2">
+   version = "2.1">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -13,8 +13,9 @@
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
-            <AutocreatedTestPlanReference>
-            </AutocreatedTestPlanReference>
+            <TestPlanReference
+               reference = "container:TestPlans/UnitTests.xctestplan">
+            </TestPlanReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>

--- a/DarkModeSwitch.xcworkspace/contents.xcworkspacedata
+++ b/DarkModeSwitch.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:DarkModeSwitch.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tests/Spies/DarkModeServiceSpy.swift
+++ b/Tests/Spies/DarkModeServiceSpy.swift
@@ -15,7 +15,7 @@ final class DarkModeServiceSpy: DarkModeServiceProtocol, @unchecked Sendable {
     // MARK: - toggleMode
     
     var toggleModeCalledCount = 0
-    var toggleModeShouldThrow: Error?
+    var toggleModeShouldThrow: (any Error)?
 
     func toggleMode() async throws {
         toggleModeCalledCount += 1

--- a/Tests/Spies/FileSystemProviderSpy.swift
+++ b/Tests/Spies/FileSystemProviderSpy.swift
@@ -36,7 +36,7 @@ final class FileSystemProviderSpy: FileSystemProvider, @unchecked Sendable {
     
     var createDirectoryCalledCount = 0
     var createDirectoryReceivedArguments: [(url: URL, withIntermediateDirectories: Bool)] = []
-    var createDirectoryShouldThrow: Error?
+    var createDirectoryShouldThrow: (any Error)?
 
     func createDirectory(at url: URL, withIntermediateDirectories: Bool) throws {
         createDirectoryCalledCount += 1
@@ -50,7 +50,7 @@ final class FileSystemProviderSpy: FileSystemProvider, @unchecked Sendable {
     
     var writeDataCalledCount = 0
     var writeDataReceivedArguments: [(data: Data, url: URL, options: Data.WritingOptions)] = []
-    var writeDataShouldThrow: Error?
+    var writeDataShouldThrow: (any Error)?
 
     func writeData(_ data: Data, to url: URL, options: Data.WritingOptions) throws {
         writeDataCalledCount += 1
@@ -64,7 +64,7 @@ final class FileSystemProviderSpy: FileSystemProvider, @unchecked Sendable {
     
     var setAttributesCalledCount = 0
     var setAttributesReceivedArguments: [(attributes: [FileAttributeKey: Any], path: String)] = []
-    var setAttributesShouldThrow: Error?
+    var setAttributesShouldThrow: (any Error)?
 
     func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
         setAttributesCalledCount += 1
@@ -78,7 +78,7 @@ final class FileSystemProviderSpy: FileSystemProvider, @unchecked Sendable {
     
     var removeItemCalledCount = 0
     var removeItemReceivedArguments: [URL] = []
-    var removeItemShouldThrow: Error?
+    var removeItemShouldThrow: (any Error)?
 
     func removeItem(at url: URL) throws {
         removeItemCalledCount += 1

--- a/Tests/Spies/SchedulingServiceSpy.swift
+++ b/Tests/Spies/SchedulingServiceSpy.swift
@@ -5,7 +5,7 @@ final class SchedulingServiceSpy: SchedulingServiceProtocol, @unchecked Sendable
     // MARK: - enableAutomaticScheduling
     
     var enableAutomaticSchedulingCalledCount = 0
-    var enableAutomaticSchedulingShouldThrow: Error?
+    var enableAutomaticSchedulingShouldThrow: (any Error)?
     
     func enableAutomaticScheduling() throws {
         enableAutomaticSchedulingCalledCount += 1
@@ -17,7 +17,7 @@ final class SchedulingServiceSpy: SchedulingServiceProtocol, @unchecked Sendable
     // MARK: - disableAutomaticScheduling
     
     var disableAutomaticSchedulingCalledCount = 0
-    var disableAutomaticSchedulingShouldThrow: Error?
+    var disableAutomaticSchedulingShouldThrow: (any Error)?
     
     func disableAutomaticScheduling() throws {
         disableAutomaticSchedulingCalledCount += 1

--- a/Tests/UtilitiesTests/FileSystemProvider/DefaultFileSystemProviderTests.swift
+++ b/Tests/UtilitiesTests/FileSystemProvider/DefaultFileSystemProviderTests.swift
@@ -166,7 +166,7 @@ struct DefaultFileSystemProviderTests {
         
         let nonExistentURL = testDirectory.appendingPathComponent("does-not-exist.txt")
         
-        #expect(throws: Error.self) {
+        #expect(throws: (any Error).self) {
             try sut.removeItem(at: nonExistentURL)
         }
     }

--- a/Tests/UtilitiesTests/ProcessRunnerErrorTests.swift
+++ b/Tests/UtilitiesTests/ProcessRunnerErrorTests.swift
@@ -89,8 +89,8 @@ struct ProcessRunnerErrorTests {
     
     @Test("Error conforms to Error protocol")
     func errorConformsToErrorProtocol() {
-        let error1: Error = ProcessRunnerError.failure(code: 1, reason: "test")
-        let error2: Error = ProcessRunnerError.executionFailed(NSError(domain: "test", code: 1))
+        let error1: any Error = ProcessRunnerError.failure(code: 1, reason: "test")
+        let error2: any Error = ProcessRunnerError.executionFailed(NSError(domain: "test", code: 1))
         
         #expect(error1 is ProcessRunnerError)
         #expect(error2 is ProcessRunnerError)


### PR DESCRIPTION
This commit introduces a GitHub Actions CI workflow that includes:
- Build and test jobs for the macOS platform using Xcode
- Unit test execution with coverage report generation
- SwiftLint for code quality checks
- Swift format checking for consistent code style

The workflow enhances the project's automation and ensures code quality across contributions.
